### PR TITLE
derive Clone for Row structs

### DIFF
--- a/src/badges.rs
+++ b/src/badges.rs
@@ -8,14 +8,14 @@ use serde::Deserialize;
 use std::collections::BTreeMap as Map;
 
 /// One row of **badges.csv**.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct Row {
     pub crate_id: CrateId,
     pub badge_type: BadgeType,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum BadgeType {
     #[non_exhaustive]
@@ -100,7 +100,7 @@ pub enum BadgeType {
     },
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub enum MaintenanceStatus {
     ActivelyDeveloped,

--- a/src/categories.rs
+++ b/src/categories.rs
@@ -13,7 +13,7 @@ use std::hash::{Hash, Hasher};
 pub struct CategoryId(pub u32);
 
 /// One row of **categories.csv**.
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 #[non_exhaustive]
 pub struct Row {

--- a/src/crate_owners.rs
+++ b/src/crate_owners.rs
@@ -18,7 +18,7 @@ pub enum OwnerId {
 }
 
 /// One row of **crate_owners.csv**.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct Row {
     pub crate_id: CrateId,

--- a/src/crates.rs
+++ b/src/crates.rs
@@ -13,7 +13,7 @@ use std::hash::{Hash, Hasher};
 pub struct CrateId(pub u32);
 
 /// One row of **crates.csv**.
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 #[non_exhaustive]
 pub struct Row {

--- a/src/crates_categories.rs
+++ b/src/crates_categories.rs
@@ -5,7 +5,7 @@ use crate::crates::CrateId;
 use serde::Deserialize;
 
 /// One row of **crates_categories.csv**.
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 #[non_exhaustive]
 pub struct Row {

--- a/src/crates_keywords.rs
+++ b/src/crates_keywords.rs
@@ -5,7 +5,7 @@ use crate::keywords::KeywordId;
 use serde::Deserialize;
 
 /// One row of **crates_keywords.csv**.
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 #[non_exhaustive]
 pub struct Row {

--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Deserializer};
 use std::fmt;
 
 /// One row of **dependencies.csv**.
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 #[non_exhaustive]
 pub struct Row {

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -13,7 +13,7 @@ use std::hash::{Hash, Hasher};
 pub struct KeywordId(pub u32);
 
 /// One row of **keywords.csv**.
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 #[non_exhaustive]
 pub struct Row {

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -3,7 +3,7 @@
 use serde::Deserialize;
 
 /// One row of **metadata.csv**.
-#[derive(Deserialize, Default, Debug)]
+#[derive(Deserialize, Default, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 #[non_exhaustive]
 pub struct Row {

--- a/src/reserved_crate_names.rs
+++ b/src/reserved_crate_names.rs
@@ -3,7 +3,7 @@
 use serde::Deserialize;
 
 /// One row of **reserved_crate_names.csv**.
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 #[non_exhaustive]
 pub struct Row {

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -12,7 +12,7 @@ use std::hash::{Hash, Hasher};
 pub struct TeamId(pub u32);
 
 /// One row of **teams.csv**.
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 #[non_exhaustive]
 pub struct Row {

--- a/src/users.rs
+++ b/src/users.rs
@@ -12,7 +12,7 @@ use std::hash::{Hash, Hasher};
 pub struct UserId(pub u32);
 
 /// One row of **users.csv**.
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 #[non_exhaustive]
 pub struct Row {

--- a/src/version_downloads.rs
+++ b/src/version_downloads.rs
@@ -5,7 +5,7 @@ use chrono::NaiveDate;
 use serde::Deserialize;
 
 /// One row of **version_downloads.csv**.
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 #[non_exhaustive]
 pub struct Row {


### PR DESCRIPTION
I'm making a scraper of crates based on categories from using db-dump and it would be nice to be able to just clone the rows when you need it.