### PR TITLE
Update argument parser to clap 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,14 +42,6 @@ jobs:
       - run: cargo test --lib
       - run: cargo test --doc
 
-  msrv:
-    name: Rust 1.57.0
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@1.57.0
-      - run: cargo check
-
   clippy:
     name: Clippy
     runs-on: ubuntu-latest

--- a/concat/Cargo.toml
+++ b/concat/Cargo.toml
@@ -16,7 +16,7 @@ path = "main.rs"
 [dependencies]
 anyhow = "1.0"
 chrono = "0.4"
-clap = { version = "3.2.5", default-features = false, features = ["deprecated", "derive", "std", "suggestions"] }
+clap = { version = "4", features = ["deprecated", "derive"] }
 csv = "1.1"
 flate2 = "1.0"
 glob = "0.3"

--- a/concat/main.rs
+++ b/concat/main.rs
@@ -45,12 +45,12 @@ use std::str;
 use tar::Archive;
 
 #[derive(Parser, Debug)]
-#[clap(name = "db-dump-concat", author, version)]
+#[command(name = "db-dump-concat", author, version)]
 struct Opt {
-    #[clap(short, long, action)]
+    #[arg(short, long)]
     out: Option<PathBuf>,
 
-    #[clap(required = true, action)]
+    #[arg(required = true)]
     dumps: Vec<PathBuf>,
 }
 


### PR DESCRIPTION
Release announcement: https://epage.github.io/blog/2022/09/clap4/