### PR TITLE
Expose timestamps as DateTime<Utc>

### DIFF
--- a/src/categories.rs
+++ b/src/categories.rs
@@ -1,6 +1,6 @@
 //! <b style="font-variant:small-caps">categories.csv</b>
 
-use chrono::NaiveDateTime;
+use chrono::{DateTime, Utc};
 use serde_derive::{Deserialize, Serialize};
 use std::borrow::Borrow;
 use std::cmp::Ordering;
@@ -26,7 +26,7 @@ pub struct Row {
     pub description: String,
     pub crates_cnt: u32,
     #[serde(deserialize_with = "crate::datetime::de")]
-    pub created_at: NaiveDateTime,
+    pub created_at: DateTime<Utc>,
     pub path: String,
 }
 

--- a/src/crate_owners.rs
+++ b/src/crate_owners.rs
@@ -5,7 +5,7 @@ use crate::error::{err, Result};
 use crate::load::FromRecord;
 use crate::teams::TeamId;
 use crate::users::UserId;
-use chrono::NaiveDateTime;
+use chrono::{DateTime, Utc};
 use csv::StringRecord;
 use serde_derive::Deserialize;
 
@@ -23,7 +23,7 @@ pub enum OwnerId {
 pub struct Row {
     pub crate_id: CrateId,
     pub owner_id: OwnerId,
-    pub created_at: NaiveDateTime,
+    pub created_at: DateTime<Utc>,
     pub created_by: Option<UserId>,
 }
 
@@ -39,7 +39,7 @@ fn de(record: &StringRecord, headers: &StringRecord) -> Result<Row> {
     struct Record {
         crate_id: CrateId,
         #[serde(deserialize_with = "crate::datetime::de")]
-        created_at: NaiveDateTime,
+        created_at: DateTime<Utc>,
         created_by: Option<UserId>,
         owner_id: u32,
         owner_kind: u8,

--- a/src/crates.rs
+++ b/src/crates.rs
@@ -1,6 +1,6 @@
 //! <b style="font-variant:small-caps">crates.csv</b>
 
-use chrono::NaiveDateTime;
+use chrono::{DateTime, Utc};
 use serde_derive::{Deserialize, Serialize};
 use std::borrow::Borrow;
 use std::cmp::Ordering;
@@ -21,9 +21,9 @@ pub struct Row {
     pub id: CrateId,
     pub name: String,
     #[serde(deserialize_with = "crate::datetime::de")]
-    pub updated_at: NaiveDateTime,
+    pub updated_at: DateTime<Utc>,
     #[serde(deserialize_with = "crate::datetime::de")]
-    pub created_at: NaiveDateTime,
+    pub created_at: DateTime<Utc>,
     pub downloads: u64,
     pub description: String,
     pub homepage: Option<String>,

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -1,6 +1,6 @@
 //! <b style="font-variant:small-caps">keywords.csv</b>
 
-use chrono::NaiveDateTime;
+use chrono::{DateTime, Utc};
 use serde_derive::{Deserialize, Serialize};
 use std::borrow::Borrow;
 use std::cmp::Ordering;
@@ -23,7 +23,7 @@ pub struct Row {
     pub keyword: String,
     pub crates_cnt: u32,
     #[serde(deserialize_with = "crate::datetime::de")]
-    pub created_at: NaiveDateTime,
+    pub created_at: DateTime<Utc>,
 }
 
 impl Ord for Row {

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -2,7 +2,7 @@
 
 use crate::crates::CrateId;
 use crate::users::UserId;
-use chrono::NaiveDateTime;
+use chrono::{DateTime, Utc};
 use semver::Version;
 use serde::de::{Deserializer, Unexpected, Visitor};
 use serde_derive::{Deserialize, Serialize};
@@ -29,9 +29,9 @@ pub struct Row {
     #[serde(deserialize_with = "version")]
     pub num: Version,
     #[serde(deserialize_with = "crate::datetime::de")]
-    pub updated_at: NaiveDateTime,
+    pub updated_at: DateTime<Utc>,
     #[serde(deserialize_with = "crate::datetime::de")]
-    pub created_at: NaiveDateTime,
+    pub created_at: DateTime<Utc>,
     pub downloads: u64,
     #[serde(deserialize_with = "features_map")]
     pub features: Map<String, Vec<String>>,


### PR DESCRIPTION
The `created_at` and `updated_at` timestamps in the db dump CSV do not mention a time zone, but it's not correct to represent them as NaiveDateTime because they refer to instants in real time, just stated in UTC.