### PR TITLE
Change dates to Date<Utc>

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ graph of the resulting table. It shows crates.io download rate doubling every 9
 months, or equivalently 10&times; every 2.5 years!
 
 ```rust
-use chrono::NaiveDate;
+use chrono::{Date, Utc};
 use std::collections::BTreeMap as Map;
 
 fn main() -> db_dump::Result<()> {
-    let mut downloads = Map::<NaiveDate, u64>::new();
+    let mut downloads = Map::<Date<Utc>, u64>::new();
     db_dump::Loader::new()
         .version_downloads(|row| {
             *downloads.entry(row.date).or_default() += row.downloads;

--- a/examples/crate-downloads.rs
+++ b/examples/crate-downloads.rs
@@ -2,7 +2,7 @@
 //!
 //! Computes time series of downloads of one specific crate.
 
-use chrono::NaiveDate;
+use chrono::{Date, Utc};
 use std::collections::{BTreeMap as Map, BTreeSet as Set};
 
 const CRATE: &str = "syn";
@@ -33,7 +33,7 @@ fn main() -> db_dump::Result<()> {
     }
 
     // Add up downloads across all version of the crate by day.
-    let mut downloads = Map::<NaiveDate, u64>::new();
+    let mut downloads = Map::<Date<Utc>, u64>::new();
     for stat in version_downloads {
         if version_ids.contains(&stat.version_id) {
             *downloads.entry(stat.date).or_default() += stat.downloads;

--- a/examples/total-downloads.rs
+++ b/examples/total-downloads.rs
@@ -3,11 +3,11 @@
 //! Computes time series of total downloads by day across all crates on
 //! crates.io.
 
-use chrono::NaiveDate;
+use chrono::{Date, Utc};
 use std::collections::BTreeMap as Map;
 
 fn main() -> db_dump::Result<()> {
-    let mut downloads = Map::<NaiveDate, u64>::new();
+    let mut downloads = Map::<Date<Utc>, u64>::new();
     db_dump::Loader::new()
         .version_downloads(|row| {
             *downloads.entry(row.date).or_default() += row.downloads;

--- a/examples/user-downloads.rs
+++ b/examples/user-downloads.rs
@@ -3,7 +3,7 @@
 //! Computes time series of the fraction of crates.io downloads attributed to a
 //! single given user's crates.
 
-use chrono::NaiveDate;
+use chrono::{Date, Utc};
 use std::collections::{BTreeMap as Map, BTreeSet as Set};
 
 const USER: &str = "dtolnay";
@@ -51,7 +51,7 @@ fn main() -> db_dump::Result<()> {
 
     // Add up downloads across that user's crates, as well as total downloads of
     // all crates.
-    let mut downloads = Map::<NaiveDate, Downloads>::new();
+    let mut downloads = Map::<Date<Utc>, Downloads>::new();
     for stat in version_downloads {
         let entry = downloads.entry(stat.date).or_default();
         entry.all += stat.downloads;

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -4,9 +4,9 @@ use std::fmt;
 
 // The timestamps in the db dump CSV do not mention a time zone, but in reality
 // they refer to UTC.
-struct CratesioTimeVisitor;
+struct CratesioDateTimeVisitor;
 
-impl<'de> Visitor<'de> for CratesioTimeVisitor {
+impl<'de> Visitor<'de> for CratesioDateTimeVisitor {
     type Value = DateTime<Utc>;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
@@ -94,7 +94,7 @@ pub(crate) fn de<'de, D>(deserializer: D) -> Result<DateTime<Utc>, D::Error>
 where
     D: Deserializer<'de>,
 {
-    deserializer.deserialize_str(CratesioTimeVisitor)
+    deserializer.deserialize_str(CratesioDateTimeVisitor)
 }
 
 #[cfg(test)]

--- a/src/load.rs
+++ b/src/load.rs
@@ -22,11 +22,11 @@ use tar::Archive;
 /// requires far less memory.
 ///
 /// ```no_run
-/// use chrono::NaiveDate;
+/// use chrono::{Date, Utc};
 /// use std::collections::BTreeMap as Map;
 ///
 /// fn main() -> db_dump::Result<()> {
-///     let mut downloads = Map::<NaiveDate, u64>::new();
+///     let mut downloads = Map::<Date<Utc>, u64>::new();
 ///     db_dump::Loader::new()
 ///         .version_downloads(|row| {
 ///             *downloads.entry(row.date).or_default() += row.downloads;

--- a/src/version_downloads.rs
+++ b/src/version_downloads.rs
@@ -1,7 +1,7 @@
 //! <b style="font-variant:small-caps">version_downloads.csv</b>
 
 use crate::versions::VersionId;
-use chrono::NaiveDate;
+use chrono::{Date, Utc};
 use serde_derive::Deserialize;
 
 /// One row of **version_downloads.csv**.
@@ -12,5 +12,5 @@ pub struct Row {
     pub version_id: VersionId,
     pub downloads: u64,
     #[serde(deserialize_with = "crate::date::de")]
-    pub date: NaiveDate,
+    pub date: Date<Utc>,
 }


### PR DESCRIPTION
This emphasizes that crates.io's tally of downloads per day is aligned to UTC midnights.