### PR TITLE
Silently ignore old version_authors table

### DIFF
--- a/src/load.rs
+++ b/src/load.rs
@@ -274,6 +274,8 @@ fn do_load(path: &Path, loader: &mut Loader) -> Result<()> {
             ("teams", read(teams, entry))
         } else if path.ends_with("users.csv") {
             ("users", read(users, entry))
+        } else if path.ends_with("version_authors.csv") {
+            continue; // https://github.com/rust-lang/crates.io/pull/3549
         } else if path.ends_with("version_downloads.csv") {
             ("version_downloads", read(version_downloads, entry))
         } else if path.ends_with("versions.csv") {


### PR DESCRIPTION
The data structures for this table were removed in #3, but it doesn't make sense to emit a warning on this table when loading an old db-dump.