### PR TITLE
Delete downloads column from crates.csv

### DIFF
--- a/src/crates.rs
+++ b/src/crates.rs
@@ -24,7 +24,6 @@ pub struct Row {
     pub updated_at: DateTime<Utc>,
     #[serde(deserialize_with = "crate::datetime::de")]
     pub created_at: DateTime<Utc>,
-    pub downloads: u64,
     pub description: String,
     pub homepage: Option<String>,
     pub documentation: Option<String>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,6 @@ pub struct DbDump {
     /// <td>name</td>
     /// <td>updated_at</td>
     /// <td>created_at</td>
-    /// <td>downloads</td>
     /// <td>description</td>
     /// <td>homepage</td>
     /// <td>documentation</td>


### PR DESCRIPTION
Deleted in https://github.com/rust-lang/crates.io/pull/8233 in favor of the crate_downloads.csv table.