### PR TITLE
Suppress unexpected_cfgs warning when built without build script

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,7 @@
 fn main() {
     // Warning: build.rs is not published to crates.io.
 
+    println!("cargo:rustc-cfg=check_cfg");
+    println!("cargo:rustc-check-cfg=cfg(check_cfg)");
     println!("cargo:rustc-check-cfg=cfg(db_dump_panic_on_unrecognized_csv)");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 //! [docs-rs]: https://img.shields.io/badge/docs.rs-66c2a5?style=for-the-badge&labelColor=555555&logo=docs.rs
 
 #![doc(html_root_url = "https://docs.rs/db-dump/0.7.1")]
+#![cfg_attr(not(check_cfg), allow(unexpected_cfgs))]
 #![allow(
     clippy::cast_lossless,
     clippy::cast_possible_truncation,


### PR DESCRIPTION
Followup to #36.