### PR TITLE
Resolve never_loop clippy lints

### DIFF
--- a/concat/main.rs
+++ b/concat/main.rs
@@ -19,7 +19,6 @@
     clippy::cast_lossless,
     clippy::cast_sign_loss,
     clippy::let_underscore_untyped,
-    clippy::never_loop,
     clippy::too_many_lines,
     clippy::trivially_copy_pass_by_ref,
     clippy::uninlined_format_args
@@ -218,31 +217,31 @@ where
         where
             E: serde::de::Error,
         {
-            loop {
+            'err: {
                 if string.len() != 10 {
-                    break;
+                    break 'err;
                 }
                 let year: u16 = match string[0..4].parse() {
                     Ok(year) => year,
-                    Err(_) => break,
+                    Err(_) => break 'err,
                 };
                 if string[4..5] != *"-" {
-                    break;
+                    break 'err;
                 }
                 let month: u8 = match string[5..7].parse() {
                     Ok(month) => month,
-                    Err(_) => break,
+                    Err(_) => break 'err,
                 };
                 if string[7..8] != *"-" {
-                    break;
+                    break 'err;
                 }
                 let day: u8 = match string[8..10].parse() {
                     Ok(day) => day,
-                    Err(_) => break,
+                    Err(_) => break 'err,
                 };
                 match NaiveDate::from_ymd_opt(year as i32, month as u32, day as u32) {
                     Some(naive_date) => return Ok(naive_date),
-                    None => break,
+                    None => break 'err,
                 }
             }
             Err(serde::de::Error::invalid_value(

--- a/src/date.rs
+++ b/src/date.rs
@@ -308,31 +308,31 @@ impl<'de> Visitor<'de> for CratesioDateVisitor {
     where
         E: serde::de::Error,
     {
-        loop {
+        'err: {
             if string.len() != 10 {
-                break;
+                break 'err;
             }
             let year: u16 = match string[0..4].parse() {
                 Ok(year) => year,
-                Err(_) => break,
+                Err(_) => break 'err,
             };
             if string[4..5] != *"-" {
-                break;
+                break 'err;
             }
             let month: u8 = match string[5..7].parse() {
                 Ok(month) => month,
-                Err(_) => break,
+                Err(_) => break 'err,
             };
             if string[7..8] != *"-" {
-                break;
+                break 'err;
             }
             let day: u8 = match string[8..10].parse() {
                 Ok(day) => day,
-                Err(_) => break,
+                Err(_) => break 'err,
             };
             let Some(naive_date) = NaiveDate::from_ymd_opt(year as i32, month as u32, day as u32)
             else {
-                break;
+                break 'err;
             };
             return Ok(Date::from(naive_date));
         }

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -18,67 +18,67 @@ impl<'de> Visitor<'de> for CratesioDateTimeVisitor {
         E: serde::de::Error,
     {
         // NaiveDateTime::parse_from_str(string, "%Y-%m-%d %H:%M:%S%.6f")
-        loop {
+        'err: {
             if string.len() < 19 {
-                break;
+                break 'err;
             }
             let year: u16 = match string[0..4].parse() {
                 Ok(year) => year,
-                Err(_) => break,
+                Err(_) => break 'err,
             };
             if string[4..5] != *"-" {
-                break;
+                break 'err;
             }
             let month: u8 = match string[5..7].parse() {
                 Ok(month) => month,
-                Err(_) => break,
+                Err(_) => break 'err,
             };
             if string[7..8] != *"-" {
-                break;
+                break 'err;
             }
             let day: u8 = match string[8..10].parse() {
                 Ok(day) => day,
-                Err(_) => break,
+                Err(_) => break 'err,
             };
             let Some(naive_date) = NaiveDate::from_ymd_opt(year as i32, month as u32, day as u32)
             else {
-                break;
+                break 'err;
             };
             if string[10..11] != *" " {
-                break;
+                break 'err;
             }
             let hour: u8 = match string[11..13].parse() {
                 Ok(hour) => hour,
-                Err(_) => break,
+                Err(_) => break 'err,
             };
             if string[13..14] != *":" {
-                break;
+                break 'err;
             }
             let min: u8 = match string[14..16].parse() {
                 Ok(min) => min,
-                Err(_) => break,
+                Err(_) => break 'err,
             };
             if string[16..17] != *":" {
-                break;
+                break 'err;
             }
             let sec: u8 = match string[17..19].parse() {
                 Ok(sec) => sec,
-                Err(_) => break,
+                Err(_) => break 'err,
             };
             let micro: u32 = if string.len() == 19 {
                 0
             } else if string[19..20] != *"." || string.len() > 26 {
-                break;
+                break 'err;
             } else if let Ok(micro) = string[20..].parse::<u32>() {
                 let trailing_zeros = 26 - string.len() as u32;
                 micro * 10u32.pow(trailing_zeros)
             } else {
-                break;
+                break 'err;
             };
             let Some(naive_time) =
                 NaiveTime::from_hms_micro_opt(hour as u32, min as u32, sec as u32, micro)
             else {
-                break;
+                break 'err;
             };
             let naive_date_time = NaiveDateTime::new(naive_date, naive_time);
             return Ok(Utc.from_utc_datetime(&naive_date_time));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,6 @@
     clippy::module_name_repetitions,
     clippy::must_use_candidate,
     clippy::needless_lifetimes,
-    clippy::never_loop,
     clippy::too_many_lines,
     clippy::uninlined_format_args,
     clippy::unreadable_literal,


### PR DESCRIPTION
Requires Rust 1.65+.

```console
warning: this loop never actually loops
   --> concat/main.rs:220:13
    |
220 | /             loop {
221 | |                 if string.len() != 10 {
222 | |                     break;
223 | |                 }
...   |
245 | |                 }
246 | |             }
    | |_____________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#never_loop
    = note: `-W clippy::never-loop` implied by `-W clippy::all`
    = help: to override `-W clippy::all` add `#[allow(clippy::never_loop)]`

warning: this loop never actually loops
   --> src/date.rs:311:9
    |
311 | /         loop {
312 | |             if string.len() != 10 {
313 | |                 break;
314 | |             }
...   |
337 | |             return Ok(Date::from(naive_date));
338 | |         }
    | |_________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#never_loop
    = note: `-W clippy::never-loop` implied by `-W clippy::all`
    = help: to override `-W clippy::all` add `#[allow(clippy::never_loop)]`

warning: this loop never actually loops
  --> src/datetime.rs:21:9
   |
21 | /         loop {
22 | |             if string.len() < 19 {
23 | |                 break;
24 | |             }
...  |
84 | |             return Ok(Utc.from_utc_datetime(&naive_date_time));
85 | |         }
   | |_________^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#never_loop
```