### PR TITLE
Move set visitor to module

### DIFF
--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -121,38 +121,9 @@ where
     deserializer.deserialize_str(VersionReqVisitor)
 }
 
-struct FeaturesSetVisitor;
-
-impl<'de> Visitor<'de> for FeaturesSetVisitor {
-    type Value = Vec<String>;
-
-    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter.write_str("features set")
-    }
-
-    fn visit_str<E>(self, string: &str) -> Result<Self::Value, E>
-    where
-        E: serde::de::Error,
-    {
-        if string.starts_with('{') && string.ends_with('}') {
-            let csv = &string[1..string.len() - 1];
-            if csv.is_empty() {
-                Ok(Vec::new())
-            } else {
-                Ok(csv.split(',').map(str::to_owned).collect())
-            }
-        } else {
-            Err(serde::de::Error::invalid_value(
-                Unexpected::Str(string),
-                &self,
-            ))
-        }
-    }
-}
-
 fn features_set<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
 where
     D: Deserializer<'de>,
 {
-    deserializer.deserialize_str(FeaturesSetVisitor)
+    crate::set::de(deserializer, "features set")
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ mod date;
 mod datetime;
 mod error;
 mod load;
+mod set;
 
 pub mod categories;
 pub mod crate_downloads;

--- a/src/set.rs
+++ b/src/set.rs
@@ -1,0 +1,40 @@
+use serde::de::{Deserializer, Unexpected, Visitor};
+use std::fmt;
+
+struct SetVisitor<'a> {
+    expecting: &'a str,
+}
+
+impl<'de, 'a> Visitor<'de> for SetVisitor<'a> {
+    type Value = Vec<String>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str(self.expecting)
+    }
+
+    fn visit_str<E>(self, string: &str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        if string.starts_with('{') && string.ends_with('}') {
+            let csv = &string[1..string.len() - 1];
+            if csv.is_empty() {
+                Ok(Vec::new())
+            } else {
+                Ok(csv.split(',').map(str::to_owned).collect())
+            }
+        } else {
+            Err(serde::de::Error::invalid_value(
+                Unexpected::Str(string),
+                &self,
+            ))
+        }
+    }
+}
+
+pub(crate) fn de<'de, D>(deserializer: D, expecting: &str) -> Result<Vec<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    deserializer.deserialize_str(SetVisitor { expecting })
+}


### PR DESCRIPTION
This is needed for implementing support for `bin_names` in versions.csv, which is also a set of strings.