### PR TITLE
Ignore num_no_build column of versions.csv

### DIFF
--- a/src/ignore.rs
+++ b/src/ignore.rs
@@ -1,0 +1,26 @@
+use serde::de::{Deserialize, Deserializer, Visitor};
+use std::fmt;
+
+#[derive(Default)]
+pub(crate) struct IgnoredStr;
+
+impl<'de> Deserialize<'de> for IgnoredStr {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_str(IgnoredStr)
+    }
+}
+
+impl<'de> Visitor<'de> for IgnoredStr {
+    type Value = IgnoredStr;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("string")
+    }
+
+    fn visit_str<E>(self, _ignored: &str) -> Result<Self::Value, E> {
+        Ok(IgnoredStr)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ mod bool;
 mod date;
 mod datetime;
 mod error;
+mod ignore;
 mod load;
 mod set;
 


### PR DESCRIPTION
The **num_no_build** column is identical to **num** but without build metadata. So if **num**="1.0.0+example" then **num_no_build**="1.0.0". In Rust code, there is no reason to deserialize the value of this column because it is easily reconstructed from **num**. It exists in the database only for the purpose of defining a `unique` constraint on `(crate_id, num_no_build)`.