### PR TITLE
Support UTC suffix on datetimes

### DIFF
--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -19,6 +19,7 @@ impl<'de> Visitor<'de> for CratesioDateTimeVisitor {
     {
         // NaiveDateTime::parse_from_str(string, "%Y-%m-%d %H:%M:%S%.6f")
         'err: {
+            let string = string.strip_suffix("+00").unwrap_or(string);
             if string.len() < 19 {
                 break 'err;
             }


### PR DESCRIPTION
Starting with the 2025-02-19-020019 dump, timestamps are represented in a slightly different format.

```console
Error: db_dump::Error("categories.csv: CSV deserialize error: record 1 (line: 2, byte: 56): invalid value: string \"2017-01-17 19:13:05.112025+00\", expected datetime in format 'YYYY-MM-DD HH:MM:SS.SSSSSS'")
```